### PR TITLE
fixed margin issue in fullscreen

### DIFF
--- a/style.css
+++ b/style.css
@@ -239,6 +239,8 @@ select > option {
   position: relative;
   top: 50%;
   transform: translateY(-50%);
+  max-height: none!important; 
+  min-height: none;
 }
 
 /* Media Query: Large Smartphone (Vertical) */


### PR DESCRIPTION
As asked by you I have managed to remove the margins from the video when enabling full-screen mode.\
&nbsp;
 I was able to do this by setting max/min-height of `.video-fullscreen` in style.css at line 242 to none and marked it as important.
&nbsp;
![Screenshot (43)](https://user-images.githubusercontent.com/68412756/138056581-058bb026-7d3e-4b7a-adb9-e9df5b3157da.png)

